### PR TITLE
Toolchain dir name

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -3,6 +3,7 @@ dependencies:
   - role: ansible-role-toolchain
     toolchain_url: "{{ mongo_toolchain_url }}"
     toolchain_dest: "{{ mongo_toolchain_dest }}"
+    toolchain_list_files: true
 galaxy_info:
   author: MongoDB
   description: Installs the mongo toolchain

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,6 +1,7 @@
 ---
 dependencies:
   - role: ansible-role-toolchain
+    toolchain_creates_directory: "{{ mongo_toolchain_dest }}/mongodbtoolchain"
     toolchain_url: "{{ mongo_toolchain_url }}"
     toolchain_dest: "{{ mongo_toolchain_dest }}"
     toolchain_list_files: true

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,3 +1,6 @@
 ---
 - include_tasks: setup-Debian.yml
   when: ansible_os_family == "Debian"
+
+- include_tasks: setup-Darwin.yml
+  when: ansible_os_family == "Darwin"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,4 +1,10 @@
 ---
+- name: Rename mongodbtoolchain directory
+  command: mv {{ mongo_toolchain_dest }}/{{ toolchain_top_level_directory }} {{ mongo_toolchain_dest }}/mongodbtoolchain
+  args:
+    creates: "{{ mongo_toolchain_dest }}/mongodbtoolchain"
+  when: toolchain_top_level_directory is defined
+
 - include_tasks: setup-Debian.yml
   when: ansible_os_family == "Debian"
 

--- a/tasks/setup-Darwin.yml
+++ b/tasks/setup-Darwin.yml
@@ -1,0 +1,6 @@
+---
+- name: Rename mongodbtoolchain directory
+  command: mv {{ mongo_toolchain_dest }}/{{ toolchain_top_level_directory }} {{ mongo_toolchain_dest }}/mongodbtoolchain
+  args:
+    creates: "{{ mongo_toolchain_dest }}/mongodbtoolchain"
+  when: toolchain_top_level_directory is defined

--- a/tasks/setup-Darwin.yml
+++ b/tasks/setup-Darwin.yml
@@ -1,6 +1,1 @@
 ---
-- name: Rename mongodbtoolchain directory
-  command: mv {{ mongo_toolchain_dest }}/{{ toolchain_top_level_directory }} {{ mongo_toolchain_dest }}/mongodbtoolchain
-  args:
-    creates: "{{ mongo_toolchain_dest }}/mongodbtoolchain"
-  when: toolchain_top_level_directory is defined

--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -1,3 +1,4 @@
 ---
 - name: Rename mongodbtoolchain directory
+  creates: "{{ mongo_toolchain_dest }}/mongodbtoolchain"
   command: mv {{ mongo_toolchain_dest }}/{{ toolchain_top_level_directory }} {{ mongo_toolchain_dest }}/mongodbtoolchain

--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -3,3 +3,4 @@
   command: mv {{ mongo_toolchain_dest }}/{{ toolchain_top_level_directory }} {{ mongo_toolchain_dest }}/mongodbtoolchain
   args:
     creates: "{{ mongo_toolchain_dest }}/mongodbtoolchain"
+  when: toolchain_top_level_directory is defined

--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -1,1 +1,3 @@
 ---
+- name: Rename mongodbtoolchain directory
+  command: mv {{ mongo_toolchain_dest }}/{{ toolchain_top_level_directory }} {{ mongo_toolchain_dest }}/mongodbtoolchain

--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -1,6 +1,1 @@
 ---
-- name: Rename mongodbtoolchain directory
-  command: mv {{ mongo_toolchain_dest }}/{{ toolchain_top_level_directory }} {{ mongo_toolchain_dest }}/mongodbtoolchain
-  args:
-    creates: "{{ mongo_toolchain_dest }}/mongodbtoolchain"
-  when: toolchain_top_level_directory is defined

--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -1,4 +1,5 @@
 ---
 - name: Rename mongodbtoolchain directory
-  creates: "{{ mongo_toolchain_dest }}/mongodbtoolchain"
   command: mv {{ mongo_toolchain_dest }}/{{ toolchain_top_level_directory }} {{ mongo_toolchain_dest }}/mongodbtoolchain
+  args:
+    creates: "{{ mongo_toolchain_dest }}/mongodbtoolchain"

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -3,6 +3,7 @@ distro_name: "{{ ansible_distribution }}{{ ansible_distribution_major_version }}
 distro_dict:
   Debian10: debian10
   Debian9: debian92
+  MacOSX10: osx
 distro: "{{ distro_dict[distro_name] }}"
 architecture_dict:
   x86_64: amd64


### PR DESCRIPTION
This PR allows the mongo-toolchain to use the file contents passed from the parent toolchain role in order to name the toolchain directory properly.