### PR TITLE
Revisions directory

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,3 +2,4 @@
 mongo_toolchain_dest: /opt
 mongo_toolchain_sha: ""
 mongo_toolchain_url: https://s3.amazonaws.com/boxes.10gen.com/build/toolchain/mongodbtoolchain-{{ distro }}-{{ mongo_toolchain_sha }}.tar.gz
+mongo_toolchain_revisions_directory: /opt/mongodbtoolchain/revisions

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,10 +1,11 @@
 ---
 dependencies:
   - role: ansible-role-toolchain
-    toolchain_creates_directory: "{{ mongo_toolchain_dest }}/mongodbtoolchain"
-    toolchain_url: "{{ mongo_toolchain_url }}"
-    toolchain_dest: "{{ mongo_toolchain_dest }}"
-    toolchain_list_files: true
+    vars:
+      toolchain_creates_directory: "{{ mongo_toolchain_dest }}/mongodbtoolchain"
+      toolchain_url: "{{ mongo_toolchain_url }}"
+      toolchain_dest: "{{ mongo_toolchain_dest }}"
+      toolchain_list_files: true
 galaxy_info:
   author: MongoDB
   description: Installs the mongo toolchain

--- a/molecule/default/playbook.yml
+++ b/molecule/default/playbook.yml
@@ -5,4 +5,4 @@
   roles:
     - role: ansible-role-mongo-toolchain
       vars:
-        mongo_toolchain_sha: 57df61bfe08e9c2805a38d201c5cd6c0ea414778
+        mongo_toolchain_url: https://ansible-molecule-test.s3.amazonaws.com/test_mongodbtoolchain.tar.gz

--- a/molecule/default/tests/test_default.rb
+++ b/molecule/default/tests/test_default.rb
@@ -1,28 +1,18 @@
 # frozen_string_literal: true
 
-describe file('/opt/mongodbtoolchain') do
+# rubocop:disable LineLength
+
+describe file('/opt/mongodbtoolchain/revisions/test_mongodbtoolchain/v3/bin') do
   its('type') { should eq :directory }
   it { should be_directory }
 end
 
-describe file('/opt/mongodbtoolchain/v3') do
-  its('type') { should eq :directory }
-  it { should be_directory }
-end
-
-describe file('/opt/mongodbtoolchain/v3/bin') do
-  its('type') { should eq :directory }
-  it { should be_directory }
-end
-
-describe file('/opt/mongodbtoolchain/v3/bin/gcc') do
+describe file('/opt/mongodbtoolchain/revisions/test_mongodbtoolchain/v3/bin/python3.7') do
   it { should exist }
 end
 
-# rubocop:disable LineLength
-
-describe command('/opt/mongodbtoolchain/v3/bin/gcc --version') do
-  its('stdout') { should eq "gcc (GCC) 8.2.0\nCopyright (C) 2018 Free Software Foundation, Inc.\nThis is free software; see the source for copying conditions.  There is NO\nwarranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.\n\n" }
+describe command('/opt/mongodbtoolchain/revisions/test_mongodbtoolchain/v3/bin/python3.7 --version') do
+  its('stdout') { should eq "Python 3.7.0\n" }
   its('exit_status') { should eq 0 }
 end
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,9 +1,15 @@
 ---
+- name: Ensure mongo toolchain directory exists
+  become: true
+  file:
+    path: "{{ mongo_toolchain_revisions_directory }}"
+    state: directory
+
 - name: Rename mongodbtoolchain directory
   become: true
-  command: mv {{ mongo_toolchain_dest }}/{{ toolchain_top_level_directory }} {{ mongo_toolchain_dest }}/mongodbtoolchain
+  command: mv {{ mongo_toolchain_dest }}/{{ toolchain_top_level_directory }} {{ mongo_toolchain_revisions_directory }}
   args:
-    creates: "{{ mongo_toolchain_dest }}/mongodbtoolchain"
+    creates: "{{ mongo_toolchain_revisions_directory }}/{{ toolchain_top_level_directory }}"
   when: toolchain_top_level_directory is defined
 
 - include_tasks: setup-Debian.yml


### PR DESCRIPTION
This PR first changes the tests to use a dummy toolchain that has a python3.7 executable.
The executable just echos the version when you call it, so `/opt/mongodbtoolchain/revisions/test_mongodbtoolchain/v3/bin/python3.7 --version` will echo the correct version.
It also changes where the toolchain is downloaded to. Since the download happens before the role runs, it still needs the `toolchain_top_level_directory` variable from the `ansible-role-toolchain` role.