### PR TITLE
Install script

### DIFF
--- a/molecule/default/tests/test_default.rb
+++ b/molecule/default/tests/test_default.rb
@@ -11,7 +11,21 @@ describe file('/opt/mongodbtoolchain/revisions/test_mongodbtoolchain/v3/bin/pyth
   it { should exist }
 end
 
+describe file('/opt/mongodbtoolchain/v3/bin') do
+  its('type') { should eq :directory }
+  it { should be_directory }
+end
+
+describe file('/opt/mongodbtoolchain/v3/bin/python3.7') do
+  it { should exist }
+end
+
 describe command('/opt/mongodbtoolchain/revisions/test_mongodbtoolchain/v3/bin/python3.7 --version') do
+  its('stdout') { should eq "Python 3.7.0\n" }
+  its('exit_status') { should eq 0 }
+end
+
+describe command('/opt/mongodbtoolchain/v3/bin/python3.7 --version') do
   its('stdout') { should eq "Python 3.7.0\n" }
   its('exit_status') { should eq 0 }
 end

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -12,6 +12,12 @@
     creates: "{{ mongo_toolchain_revisions_directory }}/{{ toolchain_top_level_directory }}"
   when: toolchain_top_level_directory is defined
 
+- name: Run mongodb toolchain install script
+  command: "{{ mongo_toolchain_revisions_directory }}/{{ toolchain_top_level_directory }}scripts/install.sh"
+  args:
+    creates: "{{ mongo_toolchain_dest }}/v3"
+  when: toolchain_top_level_directory is defined
+
 - include_tasks: setup-Debian.yml
   when: ansible_os_family == "Debian"
 


### PR DESCRIPTION
The toolchain includes a `install.sh` script that sets up all the proper symlinks. This PR adds a dummy script that adds a sym link and them runs the symlinked `python3.7`