### PR TITLE
fix: Removed unused architecture variable

### DIFF
--- a/vars/main.yml
+++ b/vars/main.yml
@@ -6,6 +6,3 @@ distro_dict:
   MacOSX10: osx
   RedHat8: rhel80
 distro: "{{ distro_dict[distro_name] }}"
-architecture_dict:
-  x86_64: amd64
-architecture: "{{ architecture_dict[ansible_architecture] }}"


### PR DESCRIPTION
Removed architecture from variables since it is not used in the toolchain url.