### PR TITLE
feat(BUILD-10616): add ability to set evergreen user

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Role Variables
 | `mongo_toolchain_final_dest` | Location of the mongo toolchain | string | "/opt" | no |
 | `mongo_toolchain_url` | Optional URL you can specify to download the mongo toolchain directly from | string | "" | no |
 | `mongo_toolchain_delete_old_final_dest` | Specify whether to delete the old toolchain first before downloading the new one. This can be used to install a new toolchain on a host that has space restrictions. Do not use this on static hosts as it could leave the host without the old and new toolchain installed | boolean | false | no |
-| `evergreen_user` | User that will own the toolchain folder | string | "root" | no |
+| `mongo_toolchain_evergreen_user` | User that will own the toolchain folder | string | "root" | no |
 
 Dependencies
 ------------

--- a/README.md
+++ b/README.md
@@ -48,11 +48,12 @@ Role Variables
 | `mongo_toolchain_final_dest` | Location of the mongo toolchain | string | "/opt" | no |
 | `mongo_toolchain_url` | Optional URL you can specify to download the mongo toolchain directly from | string | "" | no |
 | `mongo_toolchain_delete_old_final_dest` | Specify whether to delete the old toolchain first before downloading the new one. This can be used to install a new toolchain on a host that has space restrictions. Do not use this on static hosts as it could leave the host without the old and new toolchain installed | boolean | false | no |
+| `evergreen_user` | User that will own the toolchain folder | string | "root" | no |
 
 Dependencies
 ------------
 
-None
+Depends on the ansible-role-toolchain role to download the archive
 
 Example Playbook
 ----------------

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Role Variables
 Dependencies
 ------------
 
-Depends on the ansible-role-toolchain role to download the archive
+Depends on the [mongodb-ansible-roles.ansible-role-toolchain](https://github.com/mongodb-ansible-roles/ansible-role-toolchain) role to download the archive
 
 Example Playbook
 ----------------

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -4,4 +4,4 @@ mongo_toolchain_sha: ""
 mongo_toolchain_url: https://s3.amazonaws.com/boxes.10gen.com/build/toolchain/mongodbtoolchain-{{ distro }}-{{ mongo_toolchain_sha }}.tar.gz
 mongo_toolchain_revisions_directory: /opt/mongodbtoolchain/revisions
 mongo_toolchain_delete_old_final_dest: false
-evergreen_user: root
+mongo_toolchain_evergreen_user: root

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -4,3 +4,4 @@ mongo_toolchain_sha: ""
 mongo_toolchain_url: https://s3.amazonaws.com/boxes.10gen.com/build/toolchain/mongodbtoolchain-{{ distro }}-{{ mongo_toolchain_sha }}.tar.gz
 mongo_toolchain_revisions_directory: /opt/mongodbtoolchain/revisions
 mongo_toolchain_delete_old_final_dest: false
+evergreen_user: root

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -7,4 +7,4 @@
       vars:
         mongo_toolchain_url: https://ansible-molecule-test.s3.amazonaws.com/test_mongodbtoolchain.tar.gz
         mongo_toolchain_sha: testing_mongo_sha
-        evergreen_user: root
+        mongo_toolchain_evergreen_user: root

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -7,3 +7,4 @@
       vars:
         mongo_toolchain_url: https://ansible-molecule-test.s3.amazonaws.com/test_mongodbtoolchain.tar.gz
         mongo_toolchain_sha: testing_mongo_sha
+        evergreen_user: root

--- a/molecule/default/tests/test_default.py
+++ b/molecule/default/tests/test_default.py
@@ -33,3 +33,6 @@ def test_python(host):
     assert cmd.stdout == """Python 3.7.0
 """
     assert cmd.succeeded
+
+def test_owner(host):
+    assert "root" == host.file("/opt/mongodbtoolchain").user

--- a/molecule/default/tests/test_default.py
+++ b/molecule/default/tests/test_default.py
@@ -34,5 +34,6 @@ def test_python(host):
 """
     assert cmd.succeeded
 
+
 def test_owner(host):
     assert "root" == host.file("/opt/mongodbtoolchain").user

--- a/molecule/delete_first/converge.yml
+++ b/molecule/delete_first/converge.yml
@@ -7,3 +7,4 @@
         mongo_toolchain_url: https://ansible-molecule-test.s3.amazonaws.com/test_mongodbtoolchain.tar.gz
         mongo_toolchain_sha: testing_mongo_sha
         mongo_toolchain_delete_old_final_dest: true
+        evergreen_user: root

--- a/molecule/delete_first/converge.yml
+++ b/molecule/delete_first/converge.yml
@@ -7,4 +7,4 @@
         mongo_toolchain_url: https://ansible-molecule-test.s3.amazonaws.com/test_mongodbtoolchain.tar.gz
         mongo_toolchain_sha: testing_mongo_sha
         mongo_toolchain_delete_old_final_dest: true
-        evergreen_user: root
+        mongo_toolchain_evergreen_user: root

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -34,4 +34,4 @@
     # Make it so no one can destroy or modify the toolchain by accident
     mode: 0755
     path: /opt/mongodbtoolchain
-    owner: "{{ evergreen_user }}"
+    owner: "{{ mongo_toolchain_evergreen_user }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -26,3 +26,12 @@
   copy:
     content: "{{ mongo_toolchain_sha }}"
     dest: "{{ mongo_toolchain_final_dest }}/toolchain_version"
+
+- name: Fix toolchain permissions | Make /opt/mongodbtoolchain write-able by evergreen user
+  file:
+    state: directory
+    recurse: true
+    # Make it so no one can destroy or modify the toolchain by accident
+    mode: 0755
+    path: /opt/mongodbtoolchain
+    owner: "{{ evergreen_user }}"


### PR DESCRIPTION
### Description

Add ability to specify a user for chmod operation so we can make the toolchain directory owned by evergreen user.
