### PR TITLE
ci: try using GH_TOKEN with elevated privileges

### DIFF
--- a/.github/workflows/semantic-release.yaml
+++ b/.github/workflows/semantic-release.yaml
@@ -2,7 +2,7 @@
 jobs:
   release:
     env:
-      GITHUB_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
+      GITHUB_TOKEN: '${{ secrets.GH_TOKEN }}'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
### Description

By default, the [permissions](https://help.github.com/en/actions/configuring-and-managing-workflows/authenticating-with-the-github_token#permissions-for-the-github_token) associated with the `GITHUB_TOKEN` are limited.

This PR uses the `GH_TOKEN` secret, which is a personal access token that I created in my account with administrator access.

Let's see if this works and if it does, let's create an administrator token for the bot account.