### PR TITLE
fix: remove distro_arch variable

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,7 +1,7 @@
 ---
 mongo_toolchain_final_dest: /opt/mongodbtoolchain
 mongo_toolchain_sha: ""
-mongo_toolchain_url: "https://s3.amazonaws.com/boxes.10gen.com/build/toolchain/mongodbtoolchain-{% if mongo_toolchain_distro_name is defined %}{{ mongo_toolchain_distro_name }}-{% else %}{{ distro }}-{% endif %}{% if ansible_architecture != 'x86_64' %}{{ distro_arch }}-{% endif %}{{ mongo_toolchain_sha }}.tar.gz"
+mongo_toolchain_url: "https://s3.amazonaws.com/boxes.10gen.com/build/toolchain/mongodbtoolchain-{% if mongo_toolchain_distro_name is defined %}{{ mongo_toolchain_distro_name }}-{% else %}{{ distro }}-{% endif %}{% if ansible_architecture != 'x86_64' %}{{ distro_arch_dict[distro_arch_name] }}-{% endif %}{{ mongo_toolchain_sha }}.tar.gz"
 mongo_toolchain_revisions_directory: /opt/mongodbtoolchain/revisions
 mongo_toolchain_delete_old_final_dest: false
 mongo_toolchain_evergreen_user: root

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -17,4 +17,3 @@ distro_arch_dict:
   s390x: zseries
   aarch64: arm64
 distro: "{{ distro_dict[distro_name] }}"
-distro_arch: "{{ distro_arch_dict[distro_arch_name] }}"


### PR DESCRIPTION
The `distro_arch` variable defined in `vars/main.yml` was used by the
`mongo_toolchain_url` variable defined in `defaults/main.yml`.

The `mongo_toolchain_url` variable contained a statement:

`{% if ansible_architecture != 'x86_64' %}{{ distro_arch }}-{% endif %}`

Which reads, if the architecture is not x86_64, then use the value of
`distro_arch`. However, the `distro_arch` variable is created in memory
at runtime.

So if the architecture is x86_64, then `distro_arch` attempts to lookup
the key (`x86_64`) in the `distro_arch_dict` dictionary, which does not
exist.

Instead of adding an `x86_64` key to the `distro_arch_dict` dictionary
with the value of `""`, I removed the `distro_arch` variable entirely
and substituted it in the `mongo_toolchain_url` variable.

Considering the statement explicitly ignores x86_64 architectures, and
was only referenced by the `mongo_toolchain_url` variable, it makes more
sense to remove the variable entirely.