### PR TITLE
fix: Add SLES12 to distro dict

### DIFF
--- a/vars/main.yml
+++ b/vars/main.yml
@@ -12,6 +12,7 @@ distro_dict:
   Ubuntu20: ubuntu2004
   Ubuntu18: ubuntu1804
   Ubuntu16: ubuntu1604
+  SLES12: suse12
 distro_arch_dict:
   ppc64le: ppc64le
   s390x: zseries


### PR DESCRIPTION
### Description

Adding SLES12 to the distro dictionary